### PR TITLE
Fix 2nd usage method described in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ job 'send a few texts' do
 
   twilio do
     ['+18005555555','+18005555556'].each do |to_number|
-      send_message(to_number, 'Quick, move your car!')
+      send_message(to_number, ENV['TWILIO_FROM'], 'Quick, move your car!')
     end
   end
 

--- a/lib/pushpop-twilio.rb
+++ b/lib/pushpop-twilio.rb
@@ -27,8 +27,6 @@ module Pushpop
 
       if _to && _from && _body
         send_message(_to, _from, _body)
-      else
-        raise 'Please configure to, from, and body to send an SMS'
       end
     end
 

--- a/spec/pushpop-twilio_spec.rb
+++ b/spec/pushpop-twilio_spec.rb
@@ -43,10 +43,8 @@ describe Pushpop::Twilio do
         from '+18555555556'
       end
       step.configure
-      step.stub(:send_message).and_return(5)
-      expect {
-        step.run(365)
-      }.to raise_error /Please configure/
+      expect(step).not_to receive(:send_message)
+      step.run(365)
     end
 
     it 'should not send a message if to not specified' do
@@ -55,11 +53,8 @@ describe Pushpop::Twilio do
         body "The response is #{response}"
       end
       step.configure
-      step.stub(:send_message).and_return(5)
-      expect {
-        step.run(365)
-      }.to raise_error /Please configure/
-
+      expect(step).not_to receive(:send_message)
+      step.run(365)
     end
 
     it 'should not send a message if from not specified' do
@@ -68,10 +63,8 @@ describe Pushpop::Twilio do
         body "The response is #{response}"
       end
       step.configure
-      step.stub(:send_message).and_return(5)
-      expect {
-        step.run(365)
-      }.to raise_error /Please configure/
+      expect(step).not_to receive(:send_message)
+      step.run(365)
     end
 
   end


### PR DESCRIPTION
The included error message precludes proper usage of the 2n'd use type - using the exposed method instead of the DSL. This also fixes the example code for that use-case in the README.